### PR TITLE
feat: adds combineObjectIdsAndWhere utility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # @koopjs/geoservice-utils
 
+## Unreleased
+### Adds
+- combineObjectIdsAndWhere utility
+
 ## 2.0.0
 ### Major Changes
 - breaking change, rename "normalize" to "standardize"

--- a/README.md
+++ b/README.md
@@ -2,4 +2,5 @@
 
 This is the home of some functional utilities for working with request data from GeoService clients.
 
-### 1. [standardizeGeometryFilter](src/standardize-geometry-filter)
+### 1. [combineObjectIdsAndWhere](src/combineObjectIdsAndWhere/README.md)
+### 1. [standardizeGeometryFilter](src/standardize-geometry-filter/README.md)

--- a/src/combine-objectids-and-where/README.md
+++ b/src/combine-objectids-and-where/README.md
@@ -1,0 +1,27 @@
+# combineObjectIdsAndWhere
+
+The GeoService `objectIds` parameter is a convienance parameter for filtering features by unique-identifier.  This could also be accomplished with use of the `where` parameter.  This function transforms the `objectIds` parameter as part of the `where` parameter, so it can be more easily passed on to remote APIs.
+
+## Usage
+```js
+const objectIds = '1,2,3';
+const idField = 'id';
+const where = 'foo=\'bar\'';
+const whereClause = combineObjectIdsAndWhere({ objectIds, where, idField})
+
+/*
+Returns
+"(id in (1,2,3)) AND (foo='bar')"
+*/
+```
+
+### Parameters
+
+#### `objectIds`: string | string[] | number[] (optional)
+A list of unique-identifiers that a feature result set should include. For convenience, it can be a comma-delimited string, or string/numeric array.
+
+#### `idField`: string (optional)
+The name of the feature attribute that serves as a unique identifier. Defaults to `OBJECTID`.
+
+#### `where`: string (optional)
+The Geoservices `where` filter, a typical SQL style WHERE clause.

--- a/src/combine-objectids-and-where/index.spec.ts
+++ b/src/combine-objectids-and-where/index.spec.ts
@@ -1,0 +1,33 @@
+const {combineObjectIdsAndWhere} = require('./index');
+
+describe('combine-object-ids-and-where', () => {
+  it('should return empty string if no params', () => {
+    const clause = combineObjectIdsAndWhere({})
+    expect(clause).toBe('');
+  });
+
+  it('should return clause with objectIds string', () => {
+    const clause = combineObjectIdsAndWhere({ objectIds: '1,2,3'})
+    expect(clause).toBe('(OBJECTID IN (1,2,3))');
+  });
+
+  it('should return clause with objectIds as string', () => {
+    const clause = combineObjectIdsAndWhere({ objectIds: 'a,b'})
+    expect(clause).toBe('(OBJECTID IN (\'a\',\'b\'))');
+  });
+
+  it('should return clause with objectIds as array', () => {
+    const clause = combineObjectIdsAndWhere({ objectIds: ['a','b']})
+    expect(clause).toBe('(OBJECTID IN (\'a\',\'b\'))');
+  });
+
+  it('should return clause with objectIds string and default idField', () => {
+    const clause = combineObjectIdsAndWhere({ objectIds: '1,2,3', idField: '_id' })
+    expect(clause).toBe('(_id IN (1,2,3))');
+  });
+
+  it('should return clause with where defined', () => {
+    const clause = combineObjectIdsAndWhere({ where: 'foo=\'bar\'' })
+    expect(clause).toBe('(foo=\'bar\')');
+  });
+})

--- a/src/combine-objectids-and-where/index.ts
+++ b/src/combine-objectids-and-where/index.ts
@@ -1,0 +1,40 @@
+export interface ICombineObjectIdsAndWhereParams {
+  where?: string;
+  objectIds?: string | string[] | number[];
+  idField?: string;
+}
+
+export function combineObjectIdsAndWhere(
+  params: ICombineObjectIdsAndWhereParams,
+): string {
+  const sqlWhereComponents = [];
+  const { objectIds, where, idField = 'OBJECTID' } = params;
+
+  if (!where && objectIds === undefined) {
+    return '';
+  }
+
+  if (objectIds && idField) {
+    const objectIdsComponent = normalizeObjectIds(objectIds)
+      .map((val: string | number) => {
+        return isNaN(val as number) ? `'${val}'` : val;
+      })
+      .join(',')
+      .replace(/^/, `${idField} IN (`)
+      .replace(/$/, ')');
+
+    sqlWhereComponents.push(`(${objectIdsComponent})`);
+  }
+
+  if (where) {
+    sqlWhereComponents.push(`(${where})`);
+  }
+
+  return sqlWhereComponents.join(' AND ');
+}
+
+function normalizeObjectIds(
+  objectIds: string | string[] | number[],
+): string[] | number[] {
+  return Array.isArray(objectIds) ? objectIds : objectIds.split(',');
+}

--- a/src/standardize-geometry-filter/README.md
+++ b/src/standardize-geometry-filter/README.md
@@ -6,20 +6,7 @@ This utility accepts the noted parameters and their possible variation and retur
 
 ## Usage
 
-### Parameters
-#### `geometry` (required)
-
-The value of `geometry` can be a comma-delimited point, comma-delimited bounding box, or an ArcGIS geometry in JSON.
-
-#### `inSR` (optional)
-A spatial reference designation for the input geometry. It can be specified as either a well-known ID, and WKT string, or as a [spatial reference JSON object](https://developers.arcgis.com/documentation/common-data-types/geometry-objects.htm).
-
-#### `spatialRel` (optional)
-The spatial relationship that is intended to be applied to the input geometry.  Defaults to `'esriSpatialRelIntersects'`.
-
-#### `reprojectionSR` (optional)
-A spatial reference that the filter should be reprojected to. Reprojection can only be executed if the geometry's initial spatial reference has been defined. As with `inSR`, it can be specified as either a well-known ID, and WKT string, or as a [spatial reference JSON object](https://developers.arcgis.com/documentation/common-data-types/geometry-objects.htm).
-
+### Example
 
 ```js
 const filter = standardizeGeometryFilter({ geometry, inSR, spatialRel, reprojectionSR });
@@ -33,6 +20,20 @@ returns:
 }
 */ 
 ```
+
+### Parameters
+#### `geometry`: string | object (required)
+
+The value of `geometry` can be a comma-delimited point, comma-delimited bounding box, or an ArcGIS geometry in JSON.
+
+#### `inSR`: number | string | object (optional)
+A spatial reference designation for the input geometry. It can be specified as either a well-known ID, and WKT string, or as a [spatial reference JSON object](https://developers.arcgis.com/documentation/common-data-types/geometry-objects.htm).
+
+#### `spatialRel`: string (optional)
+The spatial relationship that is intended to be applied to the input geometry.  Defaults to `'esriSpatialRelIntersects'`.
+
+#### `reprojectionSR`: number | string | object (optional)
+A spatial reference that the filter should be reprojected to. Reprojection can only be executed if the geometry's initial spatial reference has been defined. As with `inSR`, it can be specified as either a well-known ID, and WKT string, or as a [spatial reference JSON object](https://developers.arcgis.com/documentation/common-data-types/geometry-objects.htm).
 
 ### Return 
 ```js


### PR DESCRIPTION
adds `combineObjectIdsAndWhere` utility function that add `objectIds` parameter to any existing `where` parameter.