### PR TITLE
fix: allow envelopes to have spatial reference prop

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -32,7 +32,7 @@ module.exports = {
         '@typescript-eslint/interface-name-prefix': 'off',
         '@typescript-eslint/explicit-module-boundary-types': 'off',
         '@typescript-eslint/no-explicit-any': 'off',
-        '@typescript-eslint/explicit-function-return-type': ['warning'],
+        '@typescript-eslint/explicit-function-return-type': ['warn'],
         "@typescript-eslint/typedef": [
             "error",
             {

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -32,7 +32,7 @@ module.exports = {
         '@typescript-eslint/interface-name-prefix': 'off',
         '@typescript-eslint/explicit-module-boundary-types': 'off',
         '@typescript-eslint/no-explicit-any': 'off',
-        '@typescript-eslint/explicit-function-return-type': ['error'],
+        '@typescript-eslint/explicit-function-return-type': ['warning'],
         "@typescript-eslint/typedef": [
             "error",
             {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # @koopjs/geoservice-utils
 
+## Unreleased
+### Fixed
+- envelope geometries can have their own spatial reference 
+
 ## 2.1.1
 ### Fixed
 - function needed export

--- a/src/standardize-geometry-filter/helpers.ts
+++ b/src/standardize-geometry-filter/helpers.ts
@@ -10,7 +10,10 @@ const envelopeSchema = joi.object({
   ymin: joi.number().strict().required(),
   ymax: joi.number().strict().required(),
   xmin: joi.number().strict().required(),
-  xmax: joi.number().strict().required()
+  xmax: joi.number().strict().required(),
+  spatialReference: joi.object({
+    wkid: joi.number().strict().required()
+  }).unknown(true).optional()
 });
 
 const envelopeArraySchema = joi.array().items(joi.number()).length(4);

--- a/src/standardize-geometry-filter/index.spec.ts
+++ b/src/standardize-geometry-filter/index.spec.ts
@@ -61,12 +61,13 @@ describe('standardizeGeometryFilter', () => {
     });
   });
 
-  test('envelope object with spatial reference', () => {
+  test('envelope object without spatial reference', () => {
     const result = standardizeGeometryFilter({ geometry: {
       xmin: -123,
       xmax: -122,
       ymin: 48,
       ymax: 49,
+      spatialReference: { wkid: 4326 }
     }});
     expect(result).toEqual({
       geometry: {
@@ -83,6 +84,32 @@ describe('standardizeGeometryFilter', () => {
       },
       relation: 'esriSpatialRelIntersects',
       spatialReference: undefined,
+    });
+  });
+
+  test('envelope object with spatial reference', () => {
+    const result = standardizeGeometryFilter({ geometry: {
+      xmin: -123,
+      xmax: -122,
+      ymin: 48,
+      ymax: 49,
+      spatialReference: { wkid: 4326, latestWkid: 9999 }
+    }});
+    expect(result).toEqual({
+      geometry: {
+        coordinates: [
+          [
+            [-122, 49],
+            [-123, 49],
+            [-123, 48],
+            [-122, 48],
+            [-122, 49],
+          ],
+        ],
+        type: 'Polygon',
+      },
+      relation: 'esriSpatialRelIntersects',
+      spatialReference: { wkid: 4326, latestWkid: 9999 },
     });
   });
 

--- a/src/standardize-geometry-filter/index.spec.ts
+++ b/src/standardize-geometry-filter/index.spec.ts
@@ -66,8 +66,7 @@ describe('standardizeGeometryFilter', () => {
       xmin: -123,
       xmax: -122,
       ymin: 48,
-      ymax: 49,
-      spatialReference: { wkid: 4326 }
+      ymax: 49
     }});
     expect(result).toEqual({
       geometry: {


### PR DESCRIPTION
Envelope geometries may have a `spatialReference` property.  Such envelopes should not be invalidated when using the standardizeGeometryFilter utility.