### PR TITLE
fix: allow spatial refs for all object geometries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # @koopjs/geoservice-utils
 
+## Unreleased
+## 2.1.3
+### Fixed
+- point, line, polygon geometries can have their own spatial reference 
+
 ## 2.1.2
 ### Fixed
 - envelope geometries can have their own spatial reference 

--- a/src/standardize-geometry-filter/helpers.ts
+++ b/src/standardize-geometry-filter/helpers.ts
@@ -6,62 +6,135 @@ import {
   IPolygon,
 } from '@esri/arcgis-rest-types';
 
-const envelopeSchema = joi.object({
-  ymin: joi.number().strict().required(),
-  ymax: joi.number().strict().required(),
-  xmin: joi.number().strict().required(),
-  xmax: joi.number().strict().required(),
-  spatialReference: joi.object({
-    wkid: joi.number().strict().required()
-  }).unknown(true).optional()
-});
+const envelopeSchema = joi
+  .object({
+    ymin: joi.number().strict().required(),
+    ymax: joi.number().strict().required(),
+    xmin: joi.number().strict().required(),
+    xmax: joi.number().strict().required(),
+    spatialReference: joi
+      .object({
+        wkid: joi.number().strict().required(),
+      })
+      .unknown(true)
+      .optional(),
+  })
+  .unknown(true);
 
 const envelopeArraySchema = joi.array().items(joi.number()).length(4);
 
 const pointArraySchema = joi.array().items(joi.number()).length(2);
 
-const pointSchema = joi.object({
-  y: joi.number().strict().required(),
-  x: joi.number().strict().required()
-});
+const pointSchema = joi
+  .object({
+    y: joi.number().strict().required(),
+    x: joi.number().strict().required(),
+    spatialReference: joi
+      .object({
+        wkid: joi.number().strict().required(),
+      })
+      .unknown(true)
+      .optional(),
+  })
+  .unknown(true);
 
-const multiPointSchema = joi.object({
-  points: joi.array().items(pointArraySchema).min(2)
-});
+const multiPointSchema = joi
+  .object({
+    points: joi.array().items(pointArraySchema).min(2).required(),
+    spatialReference: joi
+      .object({
+        wkid: joi.number().strict().required(),
+      })
+      .unknown(true)
+      .optional(),
+  })
+  .unknown(true);
 
-const lineStringSchema = joi.object({
-  paths: joi.array().items(joi.array().items(pointArraySchema).length(1))
-})
+const lineStringSchema = joi
+  .object({
+    paths: joi.array().items(joi.array().items(pointArraySchema).length(1)).required(),
+    spatialReference: joi
+      .object({
+        wkid: joi.number().strict().required(),
+      })
+      .unknown(true)
+      .optional(),
+  })
+  .unknown(true);
 
-const multiLineStringSchema = joi.object({
-  paths: joi.array().items(joi.array().items(pointArraySchema).min(2))
-})
+const multiLineStringSchema = joi
+  .object({
+    paths: joi.array().items(joi.array().items(pointArraySchema).min(2)).required(),
+    spatialReference: joi
+      .object({
+        wkid: joi.number().strict().required(),
+      })
+      .unknown(true)
+      .optional(),
+  })
+  .unknown(true);
 
-const polygonSchema = joi.object({
-  rings: joi.array().items(joi.array().items(pointArraySchema).length(1))
-});
+const polygonSchema = joi
+  .object({
+    rings: joi.array().items(joi.array().items(pointArraySchema).length(1)).required(),
+    spatialReference: joi
+      .object({
+        wkid: joi.number().strict().required(),
+      })
+      .unknown(true)
+      .optional(),
+  })
+  .unknown(true);
 
-const multipolygonSchema = joi.object({
-  rings: joi.array().items(joi.array().items(pointArraySchema).min(2))
-})
+const multipolygonSchema = joi
+  .object({
+    rings: joi.array().items(joi.array().items(pointArraySchema).min(2)).required(),
+    spatialReference: joi
+      .object({
+        wkid: joi.number().strict().required(),
+      })
+      .unknown(true)
+      .optional(),
+  })
+  .unknown(true);
 
-export const filterSchema = joi.alternatives(
-  envelopeSchema,
-  envelopeArraySchema,
-  pointArraySchema,
-  pointSchema,
-  multiPointSchema,
-  lineStringSchema,
-  multiLineStringSchema,
-  polygonSchema,
-  multipolygonSchema
-).required();
+export const filterSchema = joi
+  .alternatives(
+    envelopeSchema,
+    envelopeArraySchema,
+    pointArraySchema,
+    pointSchema,
+    multiPointSchema,
+    lineStringSchema,
+    multiLineStringSchema,
+    polygonSchema,
+    multipolygonSchema,
+  )
+  .required();
 
-type GeometryFilter = IEnvelope | IPoint | IPolyline | IPolygon | number[] | string;
+type GeometryFilter =
+  | IEnvelope
+  | IPoint
+  | IPolyline
+  | IPolygon
+  | number[]
+  | string;
 
-export function isArcgisEnvelope(input: GeometryFilter): boolean {
-  const { error } = envelopeSchema.validate(input);
+function passesValidation(schema: joi.Schema, input: GeometryFilter): boolean {
+  const { error } = schema.validate(input);
   return !error;
+}
+
+export function isArcgisObject(input: GeometryFilter): boolean {
+  return (
+    passesValidation(envelopeSchema, input) ||
+    passesValidation(pointSchema, input) ||
+    passesValidation(lineStringSchema, input) ||
+    passesValidation(polygonSchema, input) ||
+    passesValidation(multiPointSchema, input) ||
+    passesValidation(multiLineStringSchema, input) ||
+    passesValidation(multipolygonSchema, input)
+  );
 }
 
 export function isSinglePointArray(input: GeometryFilter): boolean {

--- a/src/standardize-geometry-filter/index.ts
+++ b/src/standardize-geometry-filter/index.ts
@@ -13,10 +13,10 @@ import bboxToPolygon from '@turf/bbox-polygon';
 import { transformSpatialReferenceToWkt } from './transform-spatial-reference-to-wkt';
 import { projectCoordinates } from './project-coordinates';
 import {
-  isArcgisEnvelope,
   isSinglePointArray,
   isEnvelopeArray,
   filterSchema,
+  isArcgisObject,
 } from './helpers';
 import {
   BBox,
@@ -94,7 +94,7 @@ function parseString(param: string): number[] {
 function extractGeometryFilterSpatialReference(
   filter: GeometryFilter,
 ): ISpatialReference | number | undefined {
-  if (isArcgisEnvelope(filter)) {
+  if (isArcgisObject(filter)) {
     return (filter as IEnvelope).spatialReference;
   }
 }


### PR DESCRIPTION
Point, Line, Polygon geometry filters (as well as multi- versions) can arrive with a `spatialReference` property.  This fix prevent faulty invalidation of such geometries.