### PR TITLE
fix: handle single number of string values for object ids

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # @koopjs/geoservice-utils
 
+## Unreleased
+### Fixed
+- handle single number of string values for object ids
+
 ## 2.2.0
 ### Added
 - parse incoming geometry strings as JSON if possible in order to support GET requests

--- a/src/combine-objectids-and-where/index.spec.ts
+++ b/src/combine-objectids-and-where/index.spec.ts
@@ -21,6 +21,21 @@ describe('combine-object-ids-and-where', () => {
     expect(clause).toBe('(OBJECTID IN (\'a\',\'b\'))');
   });
 
+  it('should return clause with string objectIds as single string', () => {
+    const clause = combineObjectIdsAndWhere({ objectIds: 'foo' })
+    expect(clause).toBe('(OBJECTID IN (\'foo\'))');
+  });
+
+  it('should return clause with stringifed number objectIds as single number', () => {
+    const clause = combineObjectIdsAndWhere({ objectIds: '123' })
+    expect(clause).toBe('(OBJECTID IN (123))');
+  });
+
+  it('should return clause with objectIds as single number', () => {
+    const clause = combineObjectIdsAndWhere({ objectIds: 123 })
+    expect(clause).toBe('(OBJECTID IN (123))');
+  });
+
   it('should return clause with objectIds string and default idField', () => {
     const clause = combineObjectIdsAndWhere({ objectIds: '1,2,3', idField: '_id' })
     expect(clause).toBe('(_id IN (1,2,3))');

--- a/src/combine-objectids-and-where/index.ts
+++ b/src/combine-objectids-and-where/index.ts
@@ -34,7 +34,11 @@ export function combineObjectIdsAndWhere(
 }
 
 function normalizeObjectIds(
-  objectIds: string | string[] | number[],
+  objectIds: string | string[] | number | number[],
 ): string[] | number[] {
-  return Array.isArray(objectIds) ? objectIds : objectIds.split(',');
+  if (Array.isArray(objectIds)) {
+    return objectIds
+  }
+
+  return (typeof objectIds === 'string') ? objectIds.split(',') : [objectIds];
 }


### PR DESCRIPTION
Properly handle incoming objectIds that are just a single numeric value.